### PR TITLE
(FEAT): Drag drop selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "ng build",
     "build:electron": "ng build --base-href=./ && cross-env NODE_ENV=production electron-forge make",
     "lint": "ng lint",
-    "test": "ng test --watch=false",
+    "test": "ng test --watch=false --code-coverage",
     "test:ci": "ng test --no-watch --no-progress --browsers=ChromeHeadless",
     "test:e2e": "playwright test",
     "start:forge": "electron-forge start"

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,19 +1,23 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 
 describe('AppComponent', () => {
   let fixture: ComponentFixture<AppComponent>;
   let component: AppComponent;
+  let store: MockStore;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
-      // declarations: [AppComponent],
+      providers: [
+        provideMockStore(),
+      ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
 
-
+    store = TestBed.inject(MockStore);
     fixture = TestBed.createComponent(AppComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,12 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { provideMockStore } from '@ngrx/store/testing';
 
 describe('AppComponent', () => {
   let fixture: ComponentFixture<AppComponent>;
   let component: AppComponent;
-  let store: MockStore;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -17,7 +16,6 @@ describe('AppComponent', () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
 
-    store = TestBed.inject(MockStore);
     fixture = TestBed.createComponent(AppComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -2,8 +2,9 @@ import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
-import { provideStore } from '@ngrx/store';
+import { provideState, provideStore } from '@ngrx/store';
+import { flowchartReducer } from './store/reducers';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes), provideStore()]
+  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes), provideStore(), provideState({ name: 'flowchart', reducer: flowchartReducer })]
 };

--- a/src/app/main-canvas/main-canvas.component.html
+++ b/src/app/main-canvas/main-canvas.component.html
@@ -1,15 +1,20 @@
 
 <p class="text-gray-400 text-center mt-32">Drag and drop elements to start building</p>
-<f-flow fDraggable>
-<f-canvas>
-    <f-connection fOutputId="output1" fInputId="input1"></f-connection>
-    <div fNode fDragHandle [fNodePosition]="{ x: 24, y: 24 }" fNodeOutput fOutputId="output1"
-    fOutputConnectableSide="right">
-    Node 1
-    </div>
-    <div fNode fDragHandle [fNodePosition]="{ x: 244, y: 24 }" fNodeInput fInputId="input1"
-    fInputConnectableSide="left">
-    Node 2
-    </div>
-</f-canvas>
+<f-flow fDraggable (fCreateNode)="onDrop($event)">
+    <f-canvas>
+        @for (node of (nodeList$ | async); track node.type) {
+            <div fNode fDragHandle [fNodePosition]="{ x: node.x, y: node.y }">
+                {{ node.type }}
+            </div>
+        }
+        <f-connection fOutputId="output1" fInputId="input1"></f-connection>
+        <div fNode fDragHandle [fNodePosition]="{ x: 24, y: 24 }" fNodeOutput fOutputId="output1"
+            fOutputConnectableSide="right">
+            Node 1
+        </div>
+        <div fNode fDragHandle [fNodePosition]="{ x: 244, y: 24 }" fNodeInput fInputId="input1"
+            fInputConnectableSide="left">
+            Node 2
+        </div>
+    </f-canvas>
 </f-flow>

--- a/src/app/main-canvas/main-canvas.component.html
+++ b/src/app/main-canvas/main-canvas.component.html
@@ -2,19 +2,10 @@
 <p class="text-gray-400 text-center mt-32">Drag and drop elements to start building</p>
 <f-flow fDraggable (fCreateNode)="onDrop($event)">
     <f-canvas>
-        @for (node of (nodeList$ | async); track node.type) {
+        @for (node of (nodeList$ | async); track node.id) {
             <div fNode fDragHandle [fNodePosition]="{ x: node.x, y: node.y }">
-                {{ node.type }}
+                {{ node.name }}
             </div>
         }
-        <f-connection fOutputId="output1" fInputId="input1"></f-connection>
-        <div fNode fDragHandle [fNodePosition]="{ x: 24, y: 24 }" fNodeOutput fOutputId="output1"
-            fOutputConnectableSide="right">
-            Node 1
-        </div>
-        <div fNode fDragHandle [fNodePosition]="{ x: 244, y: 24 }" fNodeInput fInputId="input1"
-            fInputConnectableSide="left">
-            Node 2
-        </div>
     </f-canvas>
 </f-flow>

--- a/src/app/main-canvas/main-canvas.component.spec.ts
+++ b/src/app/main-canvas/main-canvas.component.spec.ts
@@ -10,8 +10,8 @@ describe('MainCanvasComponent', () => {
   let store: MockStore;
   let dispatchSpy: jasmine.Spy;
   const mockNodes = [
-    { id: '1', type: 'Start/End', x: 100, y: 100 },
-    { id: '2', type: 'Process', x: 200, y: 200 },
+    { id: '1', name: 'Node 1', x: 100, y: 100 },
+    { id: '2', name: 'Node 2c', x: 200, y: 200 },
   ];
 
   beforeEach(async () => {
@@ -50,7 +50,6 @@ describe('MainCanvasComponent', () => {
   });
 
   it('Dropping a node on the canvas should add one to the list', () => {
-    let storeNodes: any[] = [];
     let dropEvent = {
       data: 'Test',
       rect: {

--- a/src/app/main-canvas/main-canvas.component.spec.ts
+++ b/src/app/main-canvas/main-canvas.component.spec.ts
@@ -1,17 +1,37 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
 import { MainCanvasComponent } from './main-canvas.component';
+import { selectAllNodes } from '../store/selectors';
+import { take } from 'rxjs';
 
 describe('MainCanvasComponent', () => {
   let component: MainCanvasComponent;
   let fixture: ComponentFixture<MainCanvasComponent>;
+  let store: MockStore;
+  let dispatchSpy: jasmine.Spy;
+  const mockNodes = [
+    { id: '1', type: 'Start/End', x: 100, y: 100 },
+    { id: '2', type: 'Process', x: 200, y: 200 },
+  ];
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MainCanvasComponent]
+      imports: [MainCanvasComponent],
+      providers: [
+        provideMockStore({
+          selectors: [
+            {
+              selector: selectAllNodes,
+              value: mockNodes,
+            },
+          ],
+        }),
+      ]
     })
     .compileComponents();
 
+    store = TestBed.inject(MockStore);
+    dispatchSpy = spyOn(store, 'dispatch');
     fixture = TestBed.createComponent(MainCanvasComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -19,5 +39,34 @@ describe('MainCanvasComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should have 2 nodes in the nodeList from the store', () => {
+    let storeNodes: any[] = [];
+
+    component.nodeList$.pipe(take(1)).subscribe(data => storeNodes = data);
+
+    expect(storeNodes.length).toEqual(mockNodes.length);
+  });
+
+  it('Dropping a node on the canvas should add one to the list', () => {
+    let storeNodes: any[] = [];
+    let dropEvent = {
+      data: 'Test',
+      rect: {
+        x: 100,
+        y: 100,
+        width: 100,
+        height: 100,
+        gravityCenter: {
+          x: 100,
+          y: 100
+        }
+      }
+    };
+
+    component.onDrop(dropEvent);
+
+    expect(dispatchSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/main-canvas/main-canvas.component.spec.ts
+++ b/src/app/main-canvas/main-canvas.component.spec.ts
@@ -42,7 +42,7 @@ describe('MainCanvasComponent', () => {
   });
 
   it('should have 2 nodes in the nodeList from the store', () => {
-    let storeNodes: any[] = [];
+    let storeNodes = [];
 
     component.nodeList$.pipe(take(1)).subscribe(data => storeNodes = data);
 
@@ -50,7 +50,7 @@ describe('MainCanvasComponent', () => {
   });
 
   it('Dropping a node on the canvas should add one to the list', () => {
-    let dropEvent = {
+    const dropEvent = {
       data: 'Test',
       rect: {
         x: 100,

--- a/src/app/main-canvas/main-canvas.component.ts
+++ b/src/app/main-canvas/main-canvas.component.ts
@@ -22,7 +22,7 @@ export class MainCanvasComponent {
   nodeList$ = this.store.pipe(select(selectAllNodes));
 
   onDrop(ev: FCreateNodeEvent) {
-    let node = {
+    const node = {
       id: crypto.randomUUID(), 
       name: ev.data,
       x: ev.rect.x,

--- a/src/app/main-canvas/main-canvas.component.ts
+++ b/src/app/main-canvas/main-canvas.component.ts
@@ -7,14 +7,7 @@ import { addNode } from '../store/actions';
 import { select, Store } from '@ngrx/store';
 import { AsyncPipe } from '@angular/common';
 import { FlowchartState } from '../store/reducers';
-import { Observable, pipe, tap, TapObserver } from 'rxjs';
 import { selectAllNodes } from '../store/selectors';
-
-interface Node {
-  x: number,
-  y: number,
-  type: string
-}
 
 @Component({
   selector: 'app-main-canvas',
@@ -24,30 +17,17 @@ interface Node {
 })
 export class MainCanvasComponent {
 
-  // nodeList:Node[] = [];
   readonly store = inject(Store<FlowchartState>)
 
   nodeList$ = this.store.pipe(select(selectAllNodes));
 
-  // constructor(private store: Store<FlowchartState>) {
-  //   // this.store.pipe(select(selectAllNodes)).subscribe(data => {
-  //   //   console.log('Selection', data);
-  //   //   this.nodeList = data;
-  //   // })
-  //   // this.store.select('nodes').subscribe(data => {
-  //   //   console.log('Selection', data);
-  //   //   this.nodeList = data;
-  //   // })
-  // }
-
-
   onDrop(ev: FCreateNodeEvent) {
     let node = {
-      type: 'test',
+      id: crypto.randomUUID(), 
+      name: ev.data,
       x: ev.rect.x,
       y: ev.rect.y
     }
-    console.log('addding: ', node);
     this.store.dispatch(addNode({ node }));
   }
 

--- a/src/app/main-canvas/main-canvas.component.ts
+++ b/src/app/main-canvas/main-canvas.component.ts
@@ -1,14 +1,54 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import {
+  FCreateNodeEvent,
   FFlowModule,
 } from '@foblex/flow';
+import { addNode } from '../store/actions';
+import { select, Store } from '@ngrx/store';
+import { AsyncPipe } from '@angular/common';
+import { FlowchartState } from '../store/reducers';
+import { Observable, pipe, tap, TapObserver } from 'rxjs';
+import { selectAllNodes } from '../store/selectors';
+
+interface Node {
+  x: number,
+  y: number,
+  type: string
+}
 
 @Component({
   selector: 'app-main-canvas',
-  imports: [FFlowModule],
+  imports: [FFlowModule, AsyncPipe],
   templateUrl: './main-canvas.component.html',
   styleUrl: './main-canvas.component.scss'
 })
 export class MainCanvasComponent {
+
+  // nodeList:Node[] = [];
+  readonly store = inject(Store<FlowchartState>)
+
+  nodeList$ = this.store.pipe(select(selectAllNodes));
+
+  // constructor(private store: Store<FlowchartState>) {
+  //   // this.store.pipe(select(selectAllNodes)).subscribe(data => {
+  //   //   console.log('Selection', data);
+  //   //   this.nodeList = data;
+  //   // })
+  //   // this.store.select('nodes').subscribe(data => {
+  //   //   console.log('Selection', data);
+  //   //   this.nodeList = data;
+  //   // })
+  // }
+
+
+  onDrop(ev: FCreateNodeEvent) {
+    let node = {
+      type: 'test',
+      x: ev.rect.x,
+      y: ev.rect.y
+    }
+    console.log('addding: ', node);
+    this.store.dispatch(addNode({ node }));
+  }
 
 }

--- a/src/app/node-selector/node-selector.component.html
+++ b/src/app/node-selector/node-selector.component.html
@@ -1,7 +1,6 @@
 <h2 class="text-md font-semibold mb-4">Elements</h2>
 <ul class="space-y-2">
-    <li fExternalItem class="p-2 bg-white rounded shadow hover:bg-gray-50 cursor-pointer">Node 1</li>
-    <li fExternalItem class="p-2 bg-white rounded shadow hover:bg-gray-50 cursor-pointer">Node 2</li>
-    <li fExternalItem class="p-2 bg-white rounded shadow hover:bg-gray-50 cursor-pointer">Node 3</li>
-    <li fExternalItem class="p-2 bg-white rounded shadow hover:bg-gray-50 cursor-pointer">Node 4</li>
+    @for (node of nodeTypes; track $index) {
+        <div [fData]="node.name" fExternalItem class="p-2 bg-white rounded shadow hover:bg-gray-50 cursor-pointer">{{ node.name }}</div>
+    }
 </ul>

--- a/src/app/node-selector/node-selector.component.html
+++ b/src/app/node-selector/node-selector.component.html
@@ -1,6 +1,6 @@
 <h2 class="text-md font-semibold mb-4">Elements</h2>
-<ul class="space-y-2">
+<div class="space-y-2">
     @for (node of nodeTypes; track $index) {
         <div [fData]="node.name" fExternalItem class="p-2 bg-white rounded shadow hover:bg-gray-50 cursor-pointer">{{ node.name }}</div>
     }
-</ul>
+</div>

--- a/src/app/node-selector/node-selector.component.html
+++ b/src/app/node-selector/node-selector.component.html
@@ -1,7 +1,7 @@
 <h2 class="text-md font-semibold mb-4">Elements</h2>
 <ul class="space-y-2">
-    <li class="p-2 bg-white rounded shadow hover:bg-gray-50 cursor-pointer">Node 1</li>
-    <li class="p-2 bg-white rounded shadow hover:bg-gray-50 cursor-pointer">Node 2</li>
-    <li class="p-2 bg-white rounded shadow hover:bg-gray-50 cursor-pointer">Node 3</li>
-    <li class="p-2 bg-white rounded shadow hover:bg-gray-50 cursor-pointer">Node 4</li>
+    <li fExternalItem class="p-2 bg-white rounded shadow hover:bg-gray-50 cursor-pointer">Node 1</li>
+    <li fExternalItem class="p-2 bg-white rounded shadow hover:bg-gray-50 cursor-pointer">Node 2</li>
+    <li fExternalItem class="p-2 bg-white rounded shadow hover:bg-gray-50 cursor-pointer">Node 3</li>
+    <li fExternalItem class="p-2 bg-white rounded shadow hover:bg-gray-50 cursor-pointer">Node 4</li>
 </ul>

--- a/src/app/node-selector/node-selector.component.ts
+++ b/src/app/node-selector/node-selector.component.ts
@@ -8,5 +8,18 @@ import { FFlowModule } from '@foblex/flow';
   styleUrl: './node-selector.component.scss'
 })
 export class SidebarComponent {
-
+  nodeTypes = [
+    {
+      name: 'Node 1'
+    },
+    {
+      name: 'Node 2'
+    },
+    {
+      name: 'Node 3'
+    },
+    {
+      name: 'Node 4'
+    },
+  ]
 }

--- a/src/app/node-selector/node-selector.component.ts
+++ b/src/app/node-selector/node-selector.component.ts
@@ -1,8 +1,9 @@
 import { Component } from '@angular/core';
+import { FFlowModule } from '@foblex/flow';
 
 @Component({
   selector: 'app-node-selector',
-  imports: [],
+  imports: [FFlowModule],
   templateUrl: './node-selector.component.html',
   styleUrl: './node-selector.component.scss'
 })

--- a/src/app/store/actions.ts
+++ b/src/app/store/actions.ts
@@ -1,0 +1,6 @@
+import { createAction, props } from '@ngrx/store';
+
+export const addNode = createAction(
+  '[Flowchart] Add Node',
+  props<{ node: { type: string; x: number; y: number } }>()
+);

--- a/src/app/store/actions.ts
+++ b/src/app/store/actions.ts
@@ -2,5 +2,5 @@ import { createAction, props } from '@ngrx/store';
 
 export const addNode = createAction(
   '[Flowchart] Add Node',
-  props<{ node: { type: string; x: number; y: number } }>()
+  props<{ node: { id: string, name: string; x: number; y: number } }>()
 );

--- a/src/app/store/actions.ts
+++ b/src/app/store/actions.ts
@@ -1,6 +1,7 @@
 import { createAction, props } from '@ngrx/store';
+import { Node } from './reducers';
 
 export const addNode = createAction(
   '[Flowchart] Add Node',
-  props<{ node: { id: string, name: string; x: number; y: number } }>()
+  props<{ node: Node }>()
 );

--- a/src/app/store/reducer.spec.ts
+++ b/src/app/store/reducer.spec.ts
@@ -9,7 +9,7 @@ describe('Flowchart Reducer', () => {
   });
 
   it('should add an element on addNode action', () => {
-    const node = { type: 'Node1', x: 100, y: 200 };
+    const node = { id: '1234', name: 'Node 1', x: 100, y: 200 };
     const action = addNode({ node });
     const state = flowchartReducer(initialState, action);
 
@@ -18,13 +18,13 @@ describe('Flowchart Reducer', () => {
   });
 
   it('should add multiple elements cumulatively', () => {
-    const element1 = { type: 'Node1', x: 10, y: 20 };
-    const element2 = { type: 'Node2', x: 30, y: 40 };
+    const node1 = { id: '1234', name: 'Node 1', x: 100, y: 200 };
+    const node2 = { id: '1234', name: 'Node 1', x: 100, y: 200 };
 
-    const state1 = flowchartReducer(initialState, addNode({ node: element1 }));
-    const state2 = flowchartReducer(state1, addNode({ node: element2 }));
+    const state1 = flowchartReducer(initialState, addNode({ node: node1 }));
+    const state2 = flowchartReducer(state1, addNode({ node: node2 }));
 
     expect(state2.nodes.length).toBe(2);
-    expect(state2.nodes).toEqual([element1, element2]);
+    expect(state2.nodes).toEqual([node1, node2]);
   });
 });

--- a/src/app/store/reducer.spec.ts
+++ b/src/app/store/reducer.spec.ts
@@ -1,9 +1,9 @@
-import { flowchartReducer, initialState, FlowchartState } from './reducers';
+import { flowchartReducer, initialState } from './reducers';
 import { addNode } from './actions';
 
 describe('Flowchart Reducer', () => {
   it('should return the initial state by default', () => {
-    const action = { type: 'Unknown' } as any;
+    const action = { type: 'Unknown' };
     const state = flowchartReducer(undefined, action);
     expect(state).toEqual(initialState);
   });

--- a/src/app/store/reducer.spec.ts
+++ b/src/app/store/reducer.spec.ts
@@ -1,0 +1,30 @@
+import { flowchartReducer, initialState, FlowchartState } from './reducers';
+import { addNode } from './actions';
+
+describe('Flowchart Reducer', () => {
+  it('should return the initial state by default', () => {
+    const action = { type: 'Unknown' } as any;
+    const state = flowchartReducer(undefined, action);
+    expect(state).toEqual(initialState);
+  });
+
+  it('should add an element on addNode action', () => {
+    const node = { type: 'Node1', x: 100, y: 200 };
+    const action = addNode({ node });
+    const state = flowchartReducer(initialState, action);
+
+    expect(state.nodes.length).toBe(1);
+    expect(state.nodes[0]).toEqual(node);
+  });
+
+  it('should add multiple elements cumulatively', () => {
+    const element1 = { type: 'Node1', x: 10, y: 20 };
+    const element2 = { type: 'Node2', x: 30, y: 40 };
+
+    const state1 = flowchartReducer(initialState, addNode({ node: element1 }));
+    const state2 = flowchartReducer(state1, addNode({ node: element2 }));
+
+    expect(state2.nodes.length).toBe(2);
+    expect(state2.nodes).toEqual([element1, element2]);
+  });
+});

--- a/src/app/store/reducers.ts
+++ b/src/app/store/reducers.ts
@@ -1,0 +1,18 @@
+import { createReducer, on } from '@ngrx/store';
+import { addNode } from './actions';
+
+export interface FlowchartState {
+  nodes: { type: string; x: number; y: number }[];
+}
+
+export const initialState: FlowchartState = {
+  nodes: [],
+};
+
+export const flowchartReducer = createReducer(
+  initialState,
+  on(addNode, (state, action) => ({
+    ...state,
+    nodes: [...state.nodes, action.node],
+  }))
+);

--- a/src/app/store/reducers.ts
+++ b/src/app/store/reducers.ts
@@ -1,7 +1,7 @@
 import { createReducer, on } from '@ngrx/store';
 import { addNode } from './actions';
 
-interface Node {
+export interface Node {
   x: number,
   y: number,
   name: string

--- a/src/app/store/reducers.ts
+++ b/src/app/store/reducers.ts
@@ -1,8 +1,15 @@
 import { createReducer, on } from '@ngrx/store';
 import { addNode } from './actions';
 
+interface Node {
+  x: number,
+  y: number,
+  name: string
+  id: string
+}
+
 export interface FlowchartState {
-  nodes: { type: string; x: number; y: number }[];
+  nodes: Node[];
 }
 
 export const initialState: FlowchartState = {

--- a/src/app/store/selectors.spec.ts
+++ b/src/app/store/selectors.spec.ts
@@ -1,0 +1,18 @@
+import { selectAllNodes } from './selectors';
+import { FlowchartState } from './reducers';
+
+describe('Flowchart Selectors', () => {
+  it('should select all nodes from the state', () => {
+    const mockState: FlowchartState = {
+      nodes: [
+        { id: '1', name: 'Node 1', x: 50, y: 50 },
+        { id: '2', name: 'Node 2', x: 100, y: 100 },
+      ],
+    };
+
+    const result = selectAllNodes.projector(mockState);
+    expect(result.length).toBe(2);
+    expect(result[0].id).toBe('1');
+    expect(result[1].name).toBe('Node 2');
+  });
+});

--- a/src/app/store/selectors.ts
+++ b/src/app/store/selectors.ts
@@ -1,0 +1,9 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { FlowchartState } from './reducers';
+
+export const selectFlowchartState = createFeatureSelector<FlowchartState>('flowchart');
+
+export const selectAllNodes = createSelector(
+  selectFlowchartState,
+  (state) => state.nodes
+);

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
-<body>
+<body class="overflow-hidden">
   <app-root></app-root>
 </body>
 </html>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,2 +1,2 @@
 /* You can add global styles to this file, and also import other style files */
-@use "tailwindcss";
+@use "../node_modules/tailwindcss/" as tailwind;


### PR DESCRIPTION
- Added store for state management
- Added addNode state action to save the selected node into state
- Added reducer to update state
- Added selector to query nodes from state
- Added event binding to drag node from selector onto the canvas
- Unit tests

Depends on: [(FEAT): Basic Layout](https://github.com/gooey-synths/gooey-app/pull/2)

![chrome_GJYSq95Tvt](https://github.com/user-attachments/assets/b8aaa509-ec65-407f-bbf5-60c166a25500)
